### PR TITLE
Docs site will try to read its config from yml files

### DIFF
--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -13,7 +13,7 @@ export class ConfigService {
 
   private _siteRoot: string;
 
-  private _configFileName: string = 'config.yaml';
+  private _configFileName: string = 'config.yml';
 
   constructor() {
     if (ConfigService._instance) {


### PR DESCRIPTION
Config is searched in `config.yml` files instead of `config.yaml`
