### PR TITLE
the docs-site docker image has been migrated from quay.io to dockerhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all check-env build push run bash
 
-IMAGE_TAG := quay.io/versionpress/docs-site
-IMAGE_VERSION := 2
+IMAGE_TAG := versionpress/docs-site
+IMAGE_VERSION := 3
 
 all: build
 

--- a/README.md
+++ b/README.md
@@ -43,5 +43,28 @@ Run `gulp help` to see the available tasks or inspect `package.json` to see the 
 
 ## Deployment
 
-AWS Elastic Beanstalk runs the app. TODO: document the deployment.
+Production deployment: https://docs.versionpress.net/en
 
+The docs-site is now running on our Kubernetes cluster and I still owe a deployment documentation here (TODO @stibi)
+
+## Docker
+
+https://hub.docker.com/r/versionpress/docs-site/
+
+You can use the `docker-compose.yml` to run the docs-site locally in a docker container, or run `make run` (on Linux,
+MacOS) for the same thing, a docker container will start.
+
+In both cases, make sure that you have exported a variable with path to the `versionpress/docs` content, example:
+
+```
+$ export DOCS_REPO_PATH=/home/stibi/dev/projects/versionpress/docs
+$ docker-compose up
+Starting docssite_docs-site_1
+Attaching to docssite_docs-site_1
+docs-site_1  | ConfigService initialized
+docs-site_1  | RoutingService initialized
+docs-site_1  | skipping not Markdown file - /opt/docs/content/en/03-sync/config.yml
+docs-site_1  | GET / 301 4.581 ms - 37
+```
+
+Now you can access the docs-site at `http://127.0.0.1:3000`

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The docs-site is now running on our Kubernetes cluster and I still owe a deploym
 
 https://hub.docker.com/r/versionpress/docs-site/
 
-You can use the `docker-compose.yml` to run the docs-site locally in a docker container, or run `make run` (on Linux,
-MacOS) for the same thing, a docker container will start.
+You can use the `docker-compose.yml` to run the docs-site locally in a Docker container, or run `make run` (on Linux,
+MacOS) for the same thing, a Docker container will start.
 
 In both cases, make sure that you have exported a variable with path to the `versionpress/docs` content, example:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   docs-site:
-    image: quay.io/versionpress/docs-site:2
+    image: versionpress/docs-site:3
     volumes:
       - $DOCS_REPO_PATH:/opt/docs
     ports:


### PR DESCRIPTION
We are using dockerhub as the docker repository now, so the docs-site image has been migrated there from quay.io.

Reviewers:

- [ ] @octopuss 