### PR TITLE
health check endpoint added for the docs-site app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all check-env build push run bash
 
 IMAGE_TAG := versionpress/docs-site
-IMAGE_VERSION := 3
+IMAGE_VERSION := 4
 
 all: build
 

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -31,4 +31,11 @@ router.get('/', function (request, response) {
     response.redirect(301, '/' + rs.languages[0]);
 });
 
+router.get('/healthz', function (request, response) {
+    response.set({
+      "X-Health": "OK"
+    });
+    response.status(200).send("OK");
+});
+
 export = router;


### PR DESCRIPTION
This endpoint is used by kubernetes to check health of the application.
Right now it just returns "OK" and a custom http header, which is enough to detect that the
app is running.
Later, it could be extended to actually detect if the docs content is present for example.

Reviewers:
- [x] @octopuss 
